### PR TITLE
Add methos for calcing height and fix bug of auto record frame

### DIFF
--- a/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.h
+++ b/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.h
@@ -44,6 +44,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Get height of indexPath, if cached, return it directly.
+ @warning The method only support for cells which has a corresponding nib named NSStringFromClass([cell class])
+ 
+ @param indexPath    indexPath
+ @param tableView    tableView
+ @param beforeLayout the prepare block before layout, do set model to cell or others.
+ 
+ @return height of indexPath
+ */
++ (CGFloat)heightForRowFromNibAtIndexPath:(NSIndexPath*)indexPath tableView:(MLAutoRecordFrameTableView*)tableView beforeLayout:(nullable void (^)(UITableViewCell *protypeCell))beforeLayout;
+
+/**
+ Get height of indexPath, if cached, return it directly.
+ 
+ @param indexPath        indexPath
+ @param tableView        tableView
+ @param protypeCellBlock a block which return a protype cell for calc
+ @param beforeLayout     the prepare block before layout, do set model to cell or others.
+ 
+ @return height of indexPath
+ */
++ (CGFloat)heightForRowAtIndexPath:(NSIndexPath*)indexPath tableView:(MLAutoRecordFrameTableView*)tableView protypeCellBlock:(MLAutoRecordFrameTableViewCell *(^)(Class cellCls))protypeCellBlock beforeLayout:(nullable void (^)(UITableViewCell *protypeCell))beforeLayout;
+
+/**
+ Get height of indexPath, if cached, return it directly.
  @warning The method only support for cells whose all subviews'frame can be determined with it's `layoutOfContentView` property.
  
  @param indexPath    indexPath
@@ -54,6 +78,31 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (CGFloat)heightForRowUsingPureMLLayoutAtIndexPath:(NSIndexPath*)indexPath tableView:(MLAutoRecordFrameTableView*)tableView beforeLayout:(nullable void (^)(UITableViewCell *protypeCell))beforeLayout;
 
+/**
+ Get height of indexPath, if cached, return it directly.
+ @warning The method only support for cells whose all subviews'frame can be determined with it's `layoutOfContentView` property.
+ @warning The method only support for cells which has a corresponding nib named NSStringFromClass([cell class])
+ 
+ @param indexPath    indexPath
+ @param tableView    tableView
+ @param beforeLayout the prepare block before layout, do set model to cell or others.
+ 
+ @return height of indexPath
+ */
++ (CGFloat)heightForRowUsingPureMLLayoutFromNibAtIndexPath:(NSIndexPath*)indexPath tableView:(MLAutoRecordFrameTableView*)tableView beforeLayout:(nullable void (^)(UITableViewCell *protypeCell))beforeLayout;
+
+/**
+ Get height of indexPath, if cached, return it directly.
+ @warning The method only support for cells whose all subviews'frame can be determined with it's `layoutOfContentView` property.
+ 
+ @param indexPath        indexPath
+ @param tableView        tableView
+ @param protypeCellBlock a block which return a protype cell for calc
+ @param beforeLayout     the prepare block before layout, do set model to cell or others.
+ 
+ @return height of indexPath
+ */
++ (CGFloat)heightForRowUsingPureMLLayoutAtIndexPath:(NSIndexPath*)indexPath tableView:(MLAutoRecordFrameTableView*)tableView protypeCellBlock:(MLAutoRecordFrameTableViewCell *(^)(Class cellCls))protypeCellBlock beforeLayout:(nullable void (^)(UITableViewCell *protypeCell))beforeLayout;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/MLTagViewFrameRecord/MLTagViewFrameRecord.h
+++ b/Classes/MLTagViewFrameRecord/MLTagViewFrameRecord.h
@@ -11,6 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MLTagViewFrameRecord : NSObject
 
+/**
+ the block is only valid in the root record
+ */
+@property (nonatomic, copy) BOOL (^isDirtyBlock)(id userInfo);
+
 @property (nonatomic, assign, readonly) NSInteger tag;
 @property (nonatomic, assign, readonly) CGRect frame;
 @property (nonatomic, strong, readonly) NSArray<MLTagViewFrameRecord*> *subrecords;

--- a/Classes/MLTagViewFrameRecord/MLTagViewFrameRecord.m
+++ b/Classes/MLTagViewFrameRecord/MLTagViewFrameRecord.m
@@ -74,7 +74,7 @@
 }
 
 - (NSString*)description {
-    return [self debugDescriptionWithSub:NO];
+    return [self debugDescriptionWithSub:YES];
 }
 
 - (NSString*)debugDescriptionWithSub:(BOOL)sub {


### PR DESCRIPTION
- Add methods for calcing height with custom protoye cell or protype nib cell
- Sometimes `indexPathForCell` cant find indexPath of cell, so we use
  `indexPathForRowAtPoint`
- Sometimes cell.width changed, but the cache has not removed, so we
  must check whether it is dirty.
