### PR TITLE
dequeueReusableCellWithIdentifier:forIndexPath: to help getting corresponding frame record 

### DIFF
--- a/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableView.m
+++ b/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableView.m
@@ -7,6 +7,7 @@
 
 #import "MLAutoRecordFrameTableView.h"
 #import "MLTagViewFrameRecord.h"
+#import "MLAutoRecordFrameTableViewCell.h"
 
 static inline void insertIndexToDictionary(NSInteger index, NSMutableDictionary *dictionary) {
     if (!dictionary) {
@@ -238,6 +239,14 @@ static inline void deleteIndexFromDictionary(NSInteger index, NSMutableDictionar
     }
     
     [super moveRowAtIndexPath:indexPath toIndexPath:newIndexPath];
+}
+
+- (UITableViewCell *)dequeueReusableCellWithIdentifier:(NSString *)identifier forIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [super dequeueReusableCellWithIdentifier:identifier forIndexPath:indexPath];
+    if ([cell isKindOfClass:[MLAutoRecordFrameTableViewCell class]]) {
+        ((MLAutoRecordFrameTableViewCell*)cell).indexPath = indexPath;
+    }
+    return cell;
 }
 
 - (void)reloadData {

--- a/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.h
+++ b/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.h
@@ -20,6 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) MLLayout *layoutOfContentView;
 
 /**
+ The indexPath which can be autoset with `dequeueReusableCellWithIdentifier:forIndexPath:`
+ */
+@property (nonatomic, strong) NSIndexPath *indexPath;
+
+/**
  For override , like `layoutSubviews`, but it's only called when no frame record.
  @warning Must ensure the final frame of `contentView` set. it's height is used for `heightWithTableView:indexPath:beforeLayout:` method. 
  @warning self.contentView.frame.size.height is meaningless at the begin of call.

--- a/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.m
+++ b/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.m
@@ -22,14 +22,17 @@
          Sometimes `indexPathForCell` cant find indexPath of cell, so we use `indexPathForRowAtPoint`
          But if self.height == 0, `indexPathForRowAtPoint` method returns the next indexPath,
          This is not what we expected, so we must check it.
-        */
+         */
+        //TODO: need to consider whether continue excuted `layoutSubviewsIfNoFrameRecord` below
         if (self.frame.size.height<=0.0f) {
             return;
         }
         
         indexPath = [tableView indexPathForRowAtPoint:self.center];
-        NSAssert(indexPath, @"Cant find indexPath for cell:%@",self);
+//        NSAssert(indexPath, @"Cant find indexPath for cell:%@",self);
+        //TODO: need to consider whether continue excuted `layoutSubviewsIfNoFrameRecord` below
         if (!indexPath) {
+            NSLog(@"Warning: Cant find indexPath for cell:%@",self);
             return;
         }
         

--- a/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.m
+++ b/Classes/MLTagViewFrameRecord/MLAutoRecordFrameTableViewCell.m
@@ -12,31 +12,22 @@
 
 @implementation MLAutoRecordFrameTableViewCell
 
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    
+    self.indexPath = nil;
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
     
     UITableView *tableView = [self currentTableView];
-    NSIndexPath *indexPath;
     if ([tableView isKindOfClass:[MLAutoRecordFrameTableView class]]) {
-        /* 
-         Sometimes `indexPathForCell` cant find indexPath of cell, so we use `indexPathForRowAtPoint`
-         But if self.height == 0, `indexPathForRowAtPoint` method returns the next indexPath,
-         This is not what we expected, so we must check it.
-         */
-        //TODO: need to consider whether continue excuted `layoutSubviewsIfNoFrameRecord` below
-        if (self.frame.size.height<=0.0f) {
+        if (!self.indexPath) {
             return;
         }
         
-        indexPath = [tableView indexPathForRowAtPoint:self.center];
-//        NSAssert(indexPath, @"Cant find indexPath for cell:%@",self);
-        //TODO: need to consider whether continue excuted `layoutSubviewsIfNoFrameRecord` below
-        if (!indexPath) {
-            NSLog(@"Warning: Cant find indexPath for cell:%@",self);
-            return;
-        }
-        
-        MLTagViewFrameRecord *frameRecord = [((MLAutoRecordFrameTableView*)tableView) cachedMLTagViewFrameRecordForRowAtIndexPath:indexPath];
+        MLTagViewFrameRecord *frameRecord = [((MLAutoRecordFrameTableView*)tableView) cachedMLTagViewFrameRecordForRowAtIndexPath:self.indexPath];
         if (frameRecord) {
             NSAssert(frameRecord.isDirtyBlock, @"the cached root frame record must have isDirtyBlock");
             if (!frameRecord.isDirtyBlock(@(self.contentView.frame.size.width))) {
@@ -53,7 +44,7 @@
     //layout
     [self layoutSubviewsIfNoFrameRecord];
     
-    if (indexPath) {
+    if ([tableView isKindOfClass:[MLAutoRecordFrameTableView class]]&&self.indexPath) {
         //cache
         MLTagViewFrameRecord *frameRecord = [self.contentView exportTagViewFrameRecord];
         //If new width is not equal to calc width, is dirty
@@ -61,7 +52,7 @@
         [frameRecord setIsDirtyBlock:^BOOL(id _Nonnull userInfo) {
             return [userInfo integerValue]!=calcWidth;
         }];
-        [((MLAutoRecordFrameTableView*)tableView) cacheMLTagViewFrameRecord:frameRecord forRowAtIndexPath:indexPath];
+        [((MLAutoRecordFrameTableView*)tableView) cacheMLTagViewFrameRecord:frameRecord forRowAtIndexPath:self.indexPath];
     }
 }
 
@@ -92,6 +83,8 @@
     }
     
     MLAutoRecordFrameTableViewCell *protypeCell = protypeCellBlock([self class]);
+    [protypeCell prepareForReuse];
+    protypeCell.indexPath = indexPath;
     
     if (protypeCell.frame.size.width!=tableView.frame.size.width) {
         CGRect frame = protypeCell.frame;
@@ -137,6 +130,8 @@
     }
     
     MLAutoRecordFrameTableViewCell *protypeCell = protypeCellBlock([self class]);
+    [protypeCell prepareForReuse];
+    protypeCell.indexPath = indexPath;
     
     if (beforeLayout) {
         beforeLayout(protypeCell);


### PR DESCRIPTION
`indexPathForRowAtPoint:` and `indexPathForCell:` have some strange problem, it's untrusted in `layoutSubviews` now.
So I use `dequeueReusableCellWithIdentifier:forIndexPath:` to set the value of `indexPath` property for cell. 
